### PR TITLE
Now takes cobra.Command directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Gobra generates an HTML snippet.
 import (
 	"github.com/ctessum/gobra"
 	"html/template"
+	"github.com/ctessum/gobra/example/cmd"
 )
 
 func main () {
@@ -19,44 +20,7 @@ func main () {
 	`
 	output := template.Must(template.New("outputPage").Parse(wrapper))
 
-	cmd := &gobra.Command{
-		TopLevel: true,
-		Name:          "fakewget",
-		Flags: []gobra.Flag{
-			{
-				Name:  "method",
-				Value: "GET",
-				Use: "HTTP request method"
-			},
-			{
-				Name: "header",
-				Value: "Content-Length:test/test",
-				Use: "Header",
-			},
-		},
-		Children: []*gobra.Command{
-			{
-				Name: "fetch",
-				Flags: []gobra.Flag{
-					{
-						Name:  "in-background",
-						Value: "true",
-					},
-				},
-				Children: []*gobra.Command{
-					{
-						Name: "example.tld",
-					},
-					{
-						Name: "website.site",
-					},
-				},
-			},
-			{
-				Name: "ping",
-			},
-		},
-	}
+	cmd := &gobra.CommandFromCobra{ cmd.Root }
 
 	val, err := cmd.Render();
 	if err != nil {

--- a/example/cmd/cmd.go
+++ b/example/cmd/cmd.go
@@ -1,0 +1,80 @@
+/**
+	This file is MIT licensed.
+**/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+// These variables specify confuration flags.
+var (
+	// configFile specifies the location of the configuration file.
+	configFile string
+
+	// should this dummy program runs in background
+	inBackground bool
+
+	// dummy slice
+	layers []int
+
+	// dummy starting index
+	begin int
+)
+
+func init() {
+	// Link the commands together.
+	Root.AddCommand(versionCmd)
+	Root.AddCommand(runCmd)
+	runCmd.AddCommand(steadyCmd)
+
+	// Create the configuration flags.
+	Root.PersistentFlags().StringVar(&configFile, "config", "./conf.toml", "configuration file location")
+
+	runCmd.PersistentFlags().BoolVarP(&inBackground, "inBackground", "s", false, "Program will run in background if sent true")
+	steadyCmd.Flags().IntSliceVar(&layers, "layers", []int{0, 2, 4, 6},	"Dummy slice of ints")
+	steadyCmd.Flags().IntVar(&begin, "begin", 0, "Beginning row index.")
+
+}
+
+// Root is the main command.
+var Root = &cobra.Command{
+	Use:   "dummy",
+	Short: "A dummy program",
+	Long: `This is a longer description for a dummy program, which does not do anything and only exists for the purpose of being an example.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`I'm ran.`)
+	},
+	DisableAutoGenTag: true,
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Long:  "version prints the version number of this version of dummy.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Version 1")
+	},
+	DisableAutoGenTag: true,
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the program.",
+	Long: `run runs program and executes it.`,
+	DisableAutoGenTag: true,
+}
+
+// steadyCmd is a command that runs a steady-state simulation.
+var steadyCmd = &cobra.Command{
+	Use:   "steady",
+	Short: "Run dummy in steady-state mode.",
+	Long: `steady runs program in steady-stated mode so nothing goes out of stability.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Yeah, I'm running steady")
+		return nil
+	},
+	DisableAutoGenTag: true,
+}

--- a/example/cmd/cmd.go
+++ b/example/cmd/cmd.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2017 the InMAP authors.
+This file is part of InMAP.
+
+InMAP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+InMAP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with InMAP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// These variables specify confuration flags.
+var (
+	// configFile specifies the location of the configuration file.
+	configFile string
+
+	// static specifies whether the simulation should be run with a static
+	// (vs. dynamic) resolution grid.
+	inBackground bool
+
+	// dummy slice
+	layers []int
+
+	// starting index
+	begin int
+)
+
+func init() {
+	// Link the commands together.
+	Root.AddCommand(versionCmd)
+	Root.AddCommand(runCmd)
+	runCmd.AddCommand(steadyCmd)
+
+	// Create the configuration flags.
+	Root.PersistentFlags().StringVar(&configFile, "config", "./conf.toml", "configuration file location")
+
+	runCmd.PersistentFlags().BoolVarP(&inBackground, "inBackground", "s", false, "Program will run in background if sent true")
+	steadyCmd.Flags().IntSliceVar(&layers, "layers", []int{0, 2, 4, 6},	"Dummy slice of ints")
+	steadyCmd.Flags().IntVar(&begin, "begin", 0, "Beginning row index.")
+
+}
+
+// Root is the main command.
+var Root = &cobra.Command{
+	Use:   "dummy",
+	Short: "A dummy program",
+	Long: `This is a longer description for a dummy program, which does not do anything and only exists for the purpose of being an example.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`I'm ran.`)
+	},
+	DisableAutoGenTag: true,
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Long:  "version prints the version number of this version of dummy.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Version 1")
+	},
+	DisableAutoGenTag: true,
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the program.",
+	Long: `run runs program and executes it.`,
+	DisableAutoGenTag: true,
+}
+
+// steadyCmd is a command that runs a steady-state simulation.
+var steadyCmd = &cobra.Command{
+	Use:   "steady",
+	Short: "Run dummy in steady-state mode.",
+	Long: `steady runs InMAP in steady-state mode so nothing goes out of stability.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Yeah, I'm running steady")
+		return nil
+	},
+	DisableAutoGenTag: true,
+}

--- a/example/example.go
+++ b/example/example.go
@@ -28,6 +28,7 @@ import (
 	"os" // for now
 	"github.com/ctessum/gobra"
 	"html/template"
+	"github.com/ctessum/gobra/example/cmd"
 )
 
 func main() {
@@ -55,45 +56,9 @@ func main() {
 `
 	output := template.Must(template.New("outputPage").Parse(tmpl))
 
-	cmd := &gobra.Command{
-		TopLevel: true,
-		Name:          "go",
-		Flags: []gobra.Flag{
-			{
-				Name:  "param",
-				Value: "value",
-			},
-			{
-				Name: "descr",
-				Value: "testi test",
-				Use: "Flag used for description",
-			},
-		},
-		Children: []*gobra.Command{
-			{
-				Name: "run",
-				Flags: []gobra.Flag{
-					{
-						Name:  "background",
-						Value: "true",
-					},
-				},
-				Children: []*gobra.Command{
-					{
-						Name: "example.go",
-					},
-					{
-						Name: "somefile.go",
-					},
-				},
-			},
-			{
-				Name: "test",
-			},
-		},
-	}
+	c := &gobra.CommandFromCobra{ cmd.Root }
 
-	val, err := cmd.Render();
+	val, err := c.Render();
 	if err != nil {
 		panic(err)
 	}

--- a/example/index.html
+++ b/example/index.html
@@ -18,13 +18,12 @@
 <div>
 
 
-	<div data-gobra-name=go style="">
-		<h3>go</h3>
+	<div data-gobra-name=dummy style="">
+		<h3>dummy</h3>
 		<ul>
 			
-				<li><code>--param="value"</code> </li>
+				<li><code>--config="./conf.toml"</code> configuration file location </li>
 			
-				<li><code>--descr="testi test"</code> Flag used for description</li>
 			
 		</ul>
 		
@@ -33,7 +32,7 @@
 				
 				<option value="run">run</option>
 				
-				<option value="test">test</option>
+				<option value="version">version</option>
 				
 			</select>
 			
@@ -42,33 +41,27 @@
 		<h3>run</h3>
 		<ul>
 			
-				<li><code>--background="true"</code> </li>
+				<li><code>--inBackground="false"</code> Program will run in background if sent true </li>
+			
 			
 		</ul>
 		
 			<select data-gobra-select>
 				<option selected disabled>Select</option>
 				
-				<option value="example.go">example.go</option>
-				
-				<option value="somefile.go">somefile.go</option>
+				<option value="steady">steady</option>
 				
 			</select>
 			
 				
-	<div data-gobra-name=example.go style="display:none; ">
-		<h3>example.go</h3>
+	<div data-gobra-name=steady style="display:none; ">
+		<h3>steady</h3>
 		<ul>
 			
-		</ul>
-		
-	</div>
-
 			
-				
-	<div data-gobra-name=somefile.go style="display:none; ">
-		<h3>somefile.go</h3>
-		<ul>
+				<li><code>--begin="0"</code> Beginning row index. </li>
+			
+				<li><code>--layers="[0,2,4,6]"</code> Dummy slice of ints </li>
 			
 		</ul>
 		
@@ -80,9 +73,10 @@
 
 			
 				
-	<div data-gobra-name=test style="display:none; ">
-		<h3>test</h3>
+	<div data-gobra-name=version style="display:none; ">
+		<h3>version</h3>
 		<ul>
+			
 			
 		</ul>
 		


### PR DESCRIPTION
This PR includes:

* Taking cobra.Command directly instead of specifying our own gobra.Command. This is possible by wrapping a cobra.Command like so:

```go
c := gobra.CommandFromCobra{ cmd.Root } // where cmd.Root is of type cobra.Command
// c.Render() will generate an HTML snippet like before.
```

This PR shouldn't include previous commits... :crossed_fingers: 