### PR TITLE
Dummy API now available. Also serves the front-end.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ func main () {
 		panic(err)
 	}
 
-	f, err := os.Create("out.html")
+	f, err := os.Create("index.html")
 
 	output.Execute(f, template.HTML(val))
+
+	server := gobra.Server { 8080, false, false }
+	server.Start()
 }
 
 ```

--- a/example/example.go
+++ b/example/example.go
@@ -25,7 +25,8 @@ SOFTWARE.
 package main
 
 import (
-	"os" // for now
+	"fmt"
+	"os"
 	"github.com/ctessum/gobra"
 	"html/template"
 	"github.com/ctessum/gobra/example/cmd"
@@ -44,19 +45,24 @@ func main() {
 	</style>
 </head>
 <body>
-	<div class="container">
-		<h1>Some valid HTML page here</h1>
-		<span>Below is a div where Gobra is added.</span>
-		<div>
-			{{.}}
-		</div>
+<div class="container">
+	<h1>Some valid HTML page here</h1>
+	<span>Below is a div where Gobra is added.</span>
+	<div>
+		{{.}}
 	</div>
+	<footer>
+		Add more content below. But here's a footer. 2017.
+	</footer>
+</div>
 </body>
 </html>
 `
 	output := template.Must(template.New("outputPage").Parse(tmpl))
 
-	c := &gobra.CommandFromCobra{ cmd.Root }
+	fmt.Println("Generating front-end html.")
+
+	c := &gobra.CommandFromCobra{ cmd.Root , "" }
 
 	val, err := c.Render();
 	if err != nil {
@@ -64,6 +70,11 @@ func main() {
 	}
 
 	f, err := os.Create("index.html")
-
 	output.Execute(f, template.HTML(val))
+
+	fmt.Println("Successfully generated front-end html.")
+	fmt.Println("Starting server, with front-end html/js.")
+
+	server := gobra.Server { 8080, false, false }
+	server.Start()
 }

--- a/example/index.html
+++ b/example/index.html
@@ -10,17 +10,17 @@
 	</style>
 </head>
 <body>
-	<div class="container">
-		<h1>Some valid HTML page here</h1>
-		<span>Below is a div where Gobra is added.</span>
-		<div>
-			
-<div>
+<div class="container">
+	<h1>Some valid HTML page here</h1>
+	<span>Below is a div where Gobra is added.</span>
+	<div>
+		
+<div id="gobra-dummy">
 
 
 	<div data-gobra-name=dummy style="">
 		<h3>dummy</h3>
-		<ul>
+		<ul class="flags">
 			
 				<li><code>--config="./conf.toml"</code> configuration file location </li>
 			
@@ -37,9 +37,9 @@
 			</select>
 			
 				
-	<div data-gobra-name=run style="display:none; ">
+	<div data-gobra-name=run style="display:none;">
 		<h3>run</h3>
-		<ul>
+		<ul class="flags">
 			
 				<li><code>--inBackground="false"</code> Program will run in background if sent true </li>
 			
@@ -54,9 +54,9 @@
 			</select>
 			
 				
-	<div data-gobra-name=steady style="display:none; ">
+	<div data-gobra-name=steady style="display:none;">
 		<h3>steady</h3>
-		<ul>
+		<ul class="flags">
 			
 			
 				<li><code>--begin="0"</code> Beginning row index. </li>
@@ -73,9 +73,9 @@
 
 			
 				
-	<div data-gobra-name=version style="display:none; ">
+	<div data-gobra-name=version style="display:none;">
 		<h3>version</h3>
-		<ul>
+		<ul class="flags">
 			
 			
 		</ul>
@@ -86,19 +86,67 @@
 		
 	</div>
 
+<br/>
+<button>Execute</button>
+<pre class="gobraStatus" style="padding:10px; background:lightgray; height:10em; overflow-y:scroll; white-space: pre-wrap;">
+</pre>
 <script>
-	document.querySelectorAll("[data-gobra-select]").forEach( option => {
+
+let status = document.querySelector("#gobra-dummy .gobraStatus");
+	document.querySelectorAll("#gobra-dummy [data-gobra-select]").forEach( option => {
 		option.onchange = e => {
 			[...e.target.parentElement.children].forEach( el => {
 				if (el.tagName == "DIV")
 					el.style.display = (el.dataset.gobraName == e.target.value)? "" : "none";
 			})
 		}
-	})
+	});
+
+	document.querySelector("#gobra-dummy>button").onclick = e => {
+		let recurse = el => {
+			let cmds = [],
+				flags = [];
+			if (el.tagName = "DIV" && el.style.display !== "none") {
+				if (el.dataset.gobraName) { 
+					cmds.push(el.dataset.gobraName);
+					[...el.querySelector("ul.flags").querySelectorAll("code")].forEach(f => flags.push(f.textContent))
+				}
+				[...el.children].forEach( child => {
+					if (child.style.display !== "none") {
+						let childRes = recurse(child);
+						Array.prototype.push.apply(cmds, childRes[0]);
+						Array.prototype.push.apply(flags, childRes[1]);
+						return;
+					} 
+				})
+			}
+			return [cmds, flags];
+		}
+		let resultCommand = recurse(document.getElementById("gobra-dummy"));
+
+		status.textContent += "Sent data to server. \n" ;
+		status.scrollTop = status.scrollHeight;
+
+		serverSend({
+			cmds: resultCommand[0],
+			flags: resultCommand[1]
+		}).then(res => res.text()).then( d => {
+			status.textContent += "Server says: " + d + "\n";
+			status.scrollTop = status.scrollHeight;
+		})
+	}
+
+const serverAddress =  "/gobra" ;
+let serverSend = data => {
+	return fetch(serverAddress+"?data="+JSON.stringify(data));
+}
 </script>
 </div>
 
-		</div>
 	</div>
+	<footer>
+		Add more content below. But here's a footer. 2017.
+	</footer>
+</div>
 </body>
 </html>


### PR DESCRIPTION
In this Pull Request, Gobra is now a server. It now receives commands at `/gobra`, and can optionally allow Cross-Origin access, and by default also serves the front-end file that's generated by `gobra.CommandFromCobra.Render()`. This last option can be opt-out if you wish to serve the front end with something else. 

CommandFromCobra struct now has an extra field (`ServerAddress`) if you wish to run the Gobra front-end and back-end on different hosts.

Here's a quick run down on what's happening in `example.go`:

```go
// This isn't new except for the second field. 
c := &gobra.CommandFromCobra { cmd.Root, "" }

snippet, err := c.Render();
if err != nil {
   panic(err)
}

// Do something with HTML snippet here

// This part below starts the server. You can have this in a different .go file if you want don't want to generate the front-end every time.
// The first field is the port number; second field is AllowingCORS or not; third is if you want the server to also serve the front-end static HTML file. Comments can be found in gobra.go
server := gobra.Server{ 8080, false, false }
server.Start()
```