### PR TITLE
Connection is now two-way

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
-# gobra
-Gobra is a graphical user interface (GUI) for the cobra command line interface (cli).
+# Gobra
+Gobra generates web interfaces to interact with [cobra](https://github.com/spf13/cobra)
 
-# Usage
+## Usage
 
-Gobra generates an HTML snippet.
+There are two parts to Gobra: generating client-side interface and serving a HTTP API. 
+
+### Generating client-side HTML
+
+Gobra has a `CommandFromCobra` struct which takes in two arguments: a `cobra.Command` and a string which is the address for the server the client-side will connect to. If the address is left blank, the client will connect to the same server it resides.
+
+Calling `CommandFromCobra.Render()` will return an HTML string, which you can use to insert into your already existing webpage.
+
+### Running the API
+
+Gobra also has a `Server` struct which takes in 4 arguments: `cobra.Command`, port number, AllowCORS and Frontless.
+
+The `cobra.Command` argument should be the same one that you give to `CommandFromGobra`. AllowCORS is a bool determines whether the API will have `Access-Allow-Control-Origin: *` or not. If `Frontless` is true, Gobra will not serve the `index.html` file from the folder it's run.
+
+## Example
+
+Here is an example in the case where you would run both the client-side and API on the same server:
 
 ```go
 import (
@@ -20,18 +36,20 @@ func main () {
 	`
 	output := template.Must(template.New("outputPage").Parse(wrapper))
 
-	cmd := &gobra.CommandFromCobra{ cmd.Root }
+	cmd := &gobra.CommandFromCobra{ cmd.Root, "" }
 
 	val, err := cmd.Render();
 	if err != nil {
 		panic(err)
 	}
 
+	// We dump this HTML file into the current folder
 	f, err := os.Create("index.html")
-
 	output.Execute(f, template.HTML(val))
 
-	server := gobra.Server { 8080, false, false }
+	// The server will start serving the index.html file we've just made
+	// on port 8080, and the API will be served from /gobra as well.
+	server := gobra.Server { cmd.Root, 8080, false, false }
 	server.Start()
 }
 

--- a/example/cmd/cmd.go
+++ b/example/cmd/cmd.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"errors"
 	"github.com/spf13/cobra"
 )
 
@@ -43,8 +44,9 @@ var Root = &cobra.Command{
 	Use:   "dummy",
 	Short: "A dummy program",
 	Long: `This is a longer description for a dummy program, which does not do anything and only exists for the purpose of being an example.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		fmt.Println(`I'm ran.`)
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`I'm dummy!`)
+		cmd.Println("This prints to the other output")
 	},
 	DisableAutoGenTag: true,
 }
@@ -54,7 +56,8 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number",
 	Long:  "version prints the version number of this version of dummy.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Version 1")
+		fmt.Println("I'm version!")
+		cmd.Println("Version 1")
 	},
 	DisableAutoGenTag: true,
 }
@@ -64,6 +67,10 @@ var runCmd = &cobra.Command{
 	Short: "Run the program.",
 	Long: `run runs program and executes it.`,
 	DisableAutoGenTag: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.Println("Running program & stuff")
+		return nil
+	},
 }
 
 // steadyCmd is a command that runs a steady-state simulation.
@@ -72,8 +79,8 @@ var steadyCmd = &cobra.Command{
 	Short: "Run dummy in steady-state mode.",
 	Long: `steady runs program in steady-stated mode so nothing goes out of stability.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Yeah, I'm running steady")
-		return nil
+		cmd.Println("Yeah, I'm running steady")
+		return errors.New("Oh no! An error! I'm not steady")
 	},
 	DisableAutoGenTag: true,
 }

--- a/example/example.go
+++ b/example/example.go
@@ -74,7 +74,8 @@ func main() {
 
 	fmt.Println("Successfully generated front-end html.")
 	fmt.Println("Starting server, with front-end html/js.")
+	fmt.Println("------------------")
 
-	server := gobra.Server { 8080, false, false }
+	server := gobra.Server { cmd.Root, 8080, false, false }
 	server.Start()
 }

--- a/example/index.html
+++ b/example/index.html
@@ -133,6 +133,9 @@ let status = document.querySelector("#gobra-dummy .gobraStatus");
 		}).then(res => res.text()).then( d => {
 			status.textContent += "Server says: " + d + "\n";
 			status.scrollTop = status.scrollHeight;
+		}).catch(e => {
+			status.textContent += "Failed: " + e + "\n";
+			status.scrollTop = status.scrollHeight;
 		})
 	}
 


### PR DESCRIPTION
Client-side now prints message sent from server.

If you look in `cmd.go`, you'll see that anything `cmd.Println` gets fed will be printed on the server-side. I believe we're not limited just to text but also any other kind of data through output ioWriter, exposed by Cobra: https://github.com/spf13/cobra/blob/master/command.go#L233-L236

You can still print to the console, through `fmt`. Look into `cmd.go`, for example: When the user requests for `dummy version`. The local console will output "I'm version!" and the user receives "Version 1".

The instantiation of `gobra.Server` now requires a `*cobra.Command` as the first argument as well.

The next step will be resolving flags as well as arguments, etc. Let me know what you think. Currently, I think we're safe, as this only executes whatever that's in `cmd.go`. If the user tampers with the client-side (i.e., trying to run a command that's not in cmd.go), we will just run the Root command. This is because whenever the server receives the list of command/sub-command, it uses `cobra.Find`, and `cobra.Find` returns the Root command is the command isn't found in the tree.

Since I'm using `cobra.Command.Run()` instead of `cobra.Command.Execute()`, PreRun, PersistentRun aren't appear to be running, yet. I'll look into that as well. 

If this PR isn't sufficient, let me know and I'll lump it until more things are settled.