### PR TITLE
Added UI to edit flags, new API endpoint syntax, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ func main () {
 }
 
 ```
+
+## API endpoints
+
+If you decide to use Gobra only as a server, the API endpoint works like so:
+
+If the command you want to run is: `app math add --num1=3 --num2=6`
+
+You would want to make a GET request to: `//<serverAddress>/app/math/add?num1=3&num2=6`
+

--- a/example/cmd/cmd.go
+++ b/example/cmd/cmd.go
@@ -22,6 +22,9 @@ var (
 
 	// dummy starting index
 	begin int
+
+	// addition flags
+	num1, num2 int
 )
 
 func init() {
@@ -29,6 +32,7 @@ func init() {
 	Root.AddCommand(versionCmd)
 	Root.AddCommand(runCmd)
 	runCmd.AddCommand(steadyCmd)
+	runCmd.AddCommand(addition)
 
 	// Create the configuration flags.
 	Root.PersistentFlags().StringVar(&configFile, "config", "./conf.toml", "configuration file location")
@@ -36,6 +40,8 @@ func init() {
 	runCmd.PersistentFlags().BoolVarP(&inBackground, "inBackground", "s", false, "Program will run in background if sent true")
 	steadyCmd.Flags().IntSliceVar(&layers, "layers", []int{0, 2, 4, 6},	"Dummy slice of ints")
 	steadyCmd.Flags().IntVar(&begin, "begin", 0, "Beginning row index.")
+	addition.Flags().IntVar(&num1, "num1", 1, "First number")
+	addition.Flags().IntVar(&num2, "num2", 1, "Second number")
 
 }
 
@@ -44,9 +50,16 @@ var Root = &cobra.Command{
 	Use:   "dummy",
 	Short: "A dummy program",
 	Long: `This is a longer description for a dummy program, which does not do anything and only exists for the purpose of being an example.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		fmt.Println("I must run before any subcommand runs")
+		cmd.Print("I'm always printed: ")
+	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Hey, run me before Run execute")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(`I'm dummy!`)
-		cmd.Println("This prints to the other output")
+		fmt.Println("I'm dummy")
+		cmd.Println("This is supposed to print to the other output")
 	},
 	DisableAutoGenTag: true,
 }
@@ -70,6 +83,15 @@ var runCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.Println("Running program & stuff")
 		return nil
+	},
+}
+
+var addition = &cobra.Command{
+	Use: "add",
+	Short: "adds two number",
+	Long: "We perform the addition operation on two numerical operands. The operation yields the sum of two operands, which are inputted as flags.",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Println( num1 + num2 )
 	},
 }
 

--- a/example/index.html
+++ b/example/index.html
@@ -49,9 +49,26 @@
 			<select data-gobra-select>
 				<option selected disabled>Select</option>
 				
+				<option value="add">add</option>
+				
 				<option value="steady">steady</option>
 				
 			</select>
+			
+				
+	<div data-gobra-name=add style="display:none;">
+		<h3>add</h3>
+		<ul class="flags">
+			
+			
+				<li><code data-name=num1>--num1=<input value=1></input></code> First number </li>
+			
+				<li><code data-name=num2>--num2=<input value=1></input></code> Second number </li>
+			
+		</ul>
+		
+	</div>
+
 			
 				
 	<div data-gobra-name=steady style="display:none;">
@@ -59,9 +76,9 @@
 		<ul class="flags">
 			
 			
-				<li><code>--begin="0"</code> Beginning row index. </li>
+				<li><code data-name=begin>--begin=<input value=0></input></code> Beginning row index. </li>
 			
-				<li><code>--layers="[0,2,4,6]"</code> Dummy slice of ints </li>
+				<li><code data-name=layers>--layers=<input value=[0,2,4,6]></input></code> Dummy slice of ints </li>
 			
 		</ul>
 		
@@ -109,7 +126,9 @@ let status = document.querySelector("#gobra-dummy .gobraStatus");
 			if (el.tagName = "DIV" && el.style.display !== "none") {
 				if (el.dataset.gobraName) { 
 					cmds.push(el.dataset.gobraName);
-					[...el.querySelector("ul.flags").querySelectorAll("code")].forEach(f => flags.push(f.textContent))
+					[...el.querySelector("ul.flags").querySelectorAll("code")].forEach(f => {
+						if(f.children[0]) flags.push(f.dataset.name + "=" + f.children[0].value);
+					})
 				}
 				[...el.children].forEach( child => {
 					if (child.style.display !== "none") {
@@ -122,26 +141,29 @@ let status = document.querySelector("#gobra-dummy .gobraStatus");
 			}
 			return [cmds, flags];
 		}
-		let resultCommand = recurse(document.getElementById("gobra-dummy"));
+		let resultCmd = recurse(document.getElementById("gobra-dummy"));
 
-		status.textContent += "Sent data to server. \n" ;
+		status.textContent += "→ "+resultCmd.reduce((x,y) => {
+				return x.join(" ") + " " 
+					+ y.map(z => 
+						"--"+z.split("=")[0]+"=\""+z.split("=")[1]+"\""
+					).join(" ")
+			})+"\n" ;
 		status.scrollTop = status.scrollHeight;
 
-		serverSend({
-			cmds: resultCommand[0],
-			flags: resultCommand[1]
-		}).then(res => res.text()).then( d => {
-			status.textContent += "Server says: " + d + "\n";
+		serverSend(resultCmd[0], resultCmd[1])
+		.then(res => res.text()).then( d => {
+			status.textContent += "← " + d + "\n";
 			status.scrollTop = status.scrollHeight;
 		}).catch(e => {
-			status.textContent += "Failed: " + e + "\n";
+			status.textContent += "⤬ Failed communicating with server: " + e + "\n";
 			status.scrollTop = status.scrollHeight;
 		})
 	}
 
-const serverAddress =  "/gobra" ;
-let serverSend = data => {
-	return fetch(serverAddress+"?data="+JSON.stringify(data));
+const serverAddress =  "/" ;
+let serverSend = (cmds, flags) => {
+	return fetch(cmds.join("/")+"?"+flags.join("&"));
 }
 </script>
 </div>


### PR DESCRIPTION
Chris,

To check this PR, run `go run example.go` in `example/` like before.

Choose dummy > run > add in the web interface, you should see two input boxes to input number.
Clicking Execute and you would see the result. 

You should see `I'm always printed: <number>`. The "I'm always printed" part is from the root command persistent prerun. 

Changes since last PR:
* PreRun, PersistentPreRun, etc. are now working. (It turns out Cobra has a method to execute things properly)
* The API endpoint has now changed to what we've discussed last time. There's a brief explanation in README.md
* Non-persistent flags can now be edited in the web interface.

Questions:
* Right now, every time you click Execute to add two numbers, it makes a GET request to `//localhost:8080/dummy/run/add?num1=99&num2=1`, I think you might want something like: `//localhost:8080/<customString>/dummy/run/add?num1=99&num2=1`? Let me know.
* Flags are confusing to me. Would you want some of them to be non-modifiable to the users? I'm also guessing that PersistentFlags are implied by default?
For example, in `example/cmd.go`, we have persistent flags config and inBackground. I'm guessing that if someone runs `dummy run add --num1=1 --num2=9`, it is actually `dummy run add --config=./conf.toml --inBackground=false --num1=1 --num2=9`?  So somewhere down the line, I think you wouldn't want end-users to be able to change its config file or background. 

Let me know about the PR and also questions. 

Also, index.html in example/ isn't in .gitignore, it is basically just the output whenever you run the program. Do you want me to put that in .gitignore or not?