### PR TITLE
Implemented websocket

### DIFF
--- a/example/cmd/cmd.go
+++ b/example/cmd/cmd.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -78,7 +80,11 @@ var runCmd = &cobra.Command{
 	Long:              `run runs program and executes it.`,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.Println("Running program & stuff")
+		cmd.Println("Running program the program.")
+		for i := range make([]int, 10) {
+			cmd.Printf("Output: %d\n", i)
+			time.Sleep(time.Duration(200) * time.Millisecond)
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
Resolves #11 

Run `go run example/example.go`, and open localhost:8080, then execute "dummy run". You should see the logger counting from 0 to 9 with 200 milliseconds in between.

This is different in how Gobra previous works where it used to wait for the entire output to be finished before it flushes everything out.

I have not tested this with InMap since many of it does uses fmt to print directly to console, instead of making use of Viper's Command.

![image](https://user-images.githubusercontent.com/4620399/38837701-cf388fce-4187-11e8-9652-0f3054a85dfe.png)
