### PR TITLE
Added file uploading feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ If the command you want to run is: `app math add --num1=3 --num2=6`
 
 You would want to make a GET request to: `//<serverAddress>/app/math/add?num1=3&num2=6`
 
+In case you'd like to upload a file to the server, the endpoint `/upload` is for this purpose. Send a POST request with the file under the field `data`, and it'll return you with a JSON including the local filepath under `path`.
+
+Your cobra Flag must contain "\[allow upload\]" at the end of its Usage field for the web interface to enable a file upload field
+

--- a/example/cmd/cmd.go
+++ b/example/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -24,6 +25,10 @@ var (
 
 	// addition flags
 	num1, num2 int
+
+	// paths of file to print, measure
+	path string
+	path2 string
 )
 
 func init() {
@@ -32,6 +37,7 @@ func init() {
 	Root.AddCommand(runCmd)
 	runCmd.AddCommand(steadyCmd)
 	runCmd.AddCommand(addition)
+	runCmd.AddCommand(printCmd)
 
 	// Create the configuration flags.
 	Root.PersistentFlags().StringVar(&configFile, "config", "./conf.toml", "configuration file location")
@@ -41,6 +47,8 @@ func init() {
 	steadyCmd.Flags().IntVar(&begin, "begin", 0, "Beginning row index.")
 	addition.Flags().IntVar(&num1, "num1", 1, "First number")
 	addition.Flags().IntVar(&num2, "num2", 1, "Second number")
+	printCmd.Flags().StringVar(&path, "path", "" ,"filepath to determine length [allow upload]")
+	printCmd.Flags().StringVar(&path2, "path2", "", "file to print [allow upload]")
 
 }
 
@@ -50,8 +58,8 @@ var Root = &cobra.Command{
 	Short: "A dummy program",
 	Long:  `This is a longer description for a dummy program, which does not do anything and only exists for the purpose of being an example.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		fmt.Println("I must run before any subcommand runs")
-		cmd.Print("I'm always printed: ")
+		fmt.Println("I'm always printed, because I'm in PersistentPreRun. (server)")
+		cmd.Println("I'm always printed, because I'm in PersistentPreRun. (client)")
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Hey, run me before Run execute")
@@ -77,7 +85,7 @@ var versionCmd = &cobra.Command{
 var runCmd = &cobra.Command{
 	Use:               "run",
 	Short:             "Run the program.",
-	Long:              `run runs program and executes it.`,
+	Long:              `run runs program and executes it. If there's no subcommand, I'll count from 0 to 9.`,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.Println("Running program the program.")
@@ -108,4 +116,21 @@ var steadyCmd = &cobra.Command{
 		return errors.New("Oh no! An error! I'm not steady")
 	},
 	DisableAutoGenTag: true,
+}
+
+// printCmd takes a file path and prints it
+var printCmd = &cobra.Command{
+	Use:   "print",
+	Short: "prints file content",
+	Long:  "Takes in a filepath and prints its content. Easy enough.",
+	Run: func(cmd *cobra.Command, args []string) {
+		b, err := ioutil.ReadFile(path) 
+		c, err := ioutil.ReadFile(path2) 
+	    if err != nil {
+	        cmd.Println(err)
+	    }
+
+	    cmd.Println("Filesize of the first file: ", len(string(b)))
+	    cmd.Println("Content of ", path2, "is: ", string(c))
+	},
 }


### PR DESCRIPTION
Resolves #21 

Hi Chris,

This should resolves it. When the user clicks "Execute", it will find all file upload `<input>`s, uploads them individually and populates the corresponding text fields when it receives the path returned from the server. When all the paths are received, it then executes the command.

There are some quirky things about this:
1. If you click "Execute" again, the files will be uploaded again. One way to resolve this is to click "Choose File" again and "Cancel" to clear the uploading field.
2. To enable a cobra flag to be an uploaded file, you have to append "\[allow upload\]" at the end of its Usage field. See line 50 in `example/cmd/cmd.go`. [here](https://github.com/ctessum/gobra/pull/22/files#diff-0a7d176dfd083a59fd1445c649e3914dR50)
3. I also suspect this will not work well with InMap for now. This is because I remember `maybeDownload()` does not check if it's compressed if it happens to be a local file, and that it'll look for other files from the one .shp file uploaded.

For 2., I initially wanted to declare something like:
```go
var fooCmd = &cobra.Command{
   AllowUpload: true, 
   Use: "foo",
   ...
}
```
This would be great, but that would mean we'd have to tamper with cobra's source code, so I figured to detect it as a prefix of the usage message.

For 1, I think it might be possible to clear the file field on every time you click "Execute".

If you try running the example demo, it'll give you the filesize of the first file and print the content of the second one. If you choose a very large file for the second one, it might crash on the client side. This is the same reason I mentioned before - the browser doesn't like being bombarded with messages from WebSocket.

Let me know if this is is clears up the Javascript side of the issue. 

----

![image](https://user-images.githubusercontent.com/4620399/39093503-8180e96e-45d5-11e8-9d4f-3cd248633760.png)


